### PR TITLE
Set outdir in tsconfig.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "typed-cli",
   "version": "0.2.6",
   "description": "",
-  "main": "index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "lint": "eslint . --ignore-path ./.gitignore --ext .ts",
-    "test": "nyc node ./tests/unit/index.js | tap-spec",
-    "test-report": "nyc -r lcov node ./tests/unit/index.js | tap-spec",
+    "test": "nyc node ./dist/tests/unit/index.js | tap-spec",
+    "test-report": "nyc -r lcov node ./dist/tests/unit/index.js | tap-spec",
     "docs": "typedoc"
   },
   "keywords": [

--- a/pg/index.ts
+++ b/pg/index.ts
@@ -1,5 +1,5 @@
 #! /usr/bin/env node
-import {cli, option, presets} from '../';
+import {cli, option, presets} from '../index';
 
 const data = cli({
     name: 'calc',

--- a/presets/one-of.ts
+++ b/presets/one-of.ts
@@ -1,4 +1,4 @@
-import { option } from '../';
+import { option } from '../index';
 import { objMap } from '../src/utils';
 import { Option } from '../src/option';
 import { allIssues } from '../src/errors';

--- a/tests/unit/cli-helper.ts
+++ b/tests/unit/cli-helper.ts
@@ -4,7 +4,7 @@ import { createCliHelper } from '../../src/cli-helper';
 import { en_US } from '../../src/i18n';
 import { plain } from '../../src/decorator';
 import { Printer } from '../../src/printer';
-import { option } from '../../';
+import { option } from '../../index';
 
 test('createCliHelper', t => {
     let exitCode = -1;

--- a/tests/unit/command.ts
+++ b/tests/unit/command.ts
@@ -4,7 +4,7 @@ import {command, _aliases, _decl, _fn, _subCommandSet, createCommandHelper, defa
 import { Printer } from '../../src/printer';
 import { locales } from '../../src/i18n';
 import { decorators } from '../../src/decorator';
-import { option } from '../../';
+import { option } from '../../index';
 
 test('command helper result', t => {
     const handleChild = (): void => {};

--- a/tests/unit/completer.ts
+++ b/tests/unit/completer.ts
@@ -2,7 +2,7 @@ import test from 'tape';
 
 import {normalizeCompleterOptions, completeForCliDecl, completeForCommandSet} from '../../src/completer';
 import { CliDeclaration } from '../../src/type-logic';
-import { option } from '../../';
+import { option } from '../../index';
 import { prepareCliDeclaration } from '../../src/parser';
 import { oneOf } from '../../presets';
 import { CommandSet, command, prepareCommandSet } from '../../src/command';

--- a/tests/unit/option.ts
+++ b/tests/unit/option.ts
@@ -1,7 +1,7 @@
 import test from 'tape';
 
 import { getOptData } from '../../src/option';
-import { option } from '../../';
+import { option } from '../../index';
 
 test('option basic', t => {
     t.deepEqual(getOptData(option.any), {

--- a/tests/unit/parser.ts
+++ b/tests/unit/parser.ts
@@ -1,6 +1,6 @@
 import test from 'tape';
 
-import { Parser, option } from '../..';
+import { Parser, option } from '../../index';
 import { validateReport } from './pipeline';
 import { allIssues } from '../../src/errors';
 import { isError } from '../../src/report';

--- a/tests/unit/pipeline.ts
+++ b/tests/unit/pipeline.ts
@@ -1,6 +1,6 @@
 import test from 'tape';
 
-import { option } from '../../';
+import { option } from '../../index';
 import { getOptData } from '../../src/option';
 import { handleAllOptions, handleOption } from '../../src/pipeline';
 import { isError, Report } from '../../src/report';

--- a/tests/unit/printer.ts
+++ b/tests/unit/printer.ts
@@ -3,7 +3,7 @@ import test from 'tape';
 import { Printer } from '../../src/printer';
 import { en_US } from '../../src/i18n';
 import { plain } from '../../src/decorator';
-import { option } from '../../';
+import { option } from '../../index';
 import { Parser } from '../../src/parser';
 import { command } from '../../src/command';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,9 +5,11 @@
         "strict": true,
         "esModuleInterop": true,
         "inlineSourceMap": true,
-        "declaration": true
+        "declaration": true,
+        "outDir": "dist"
     },
     "exclude": [
+        "dist",
         "./tests/e2e/**/app/**/*.ts"
     ]
 }


### PR DESCRIPTION
Due to the way that typescript works in nodejs module resolution, the
index.d.ts file will load .ts files incorrectly if you publish the .js
and .d.ts files in alongside the .ts files.

Unfortunately this causes my version of typescript to attempt to compile
the module's .ts files which are not working with typescript 4.4.3!

See microsoft/TypeScript#10704 which considers
this to be 'working as intended'

The solution is to avoid outputting your .js and .d.ts files into the
same location as the .ts files.

Unfortunately, adding 'dist/index.d.ts' to the types in the package.json
caused all imports of '..' (pointing to the /index.ts file) to trigger
this issue:
microsoft/TypeScript#14538 (comment)
which I solved by changing those to '../index' or '../../index' etc.

Here is the error I get while trying to compile my project which uses
"typescript": "^4.4.3" after `npm install typed-cli:

```
node_modules/typed-cli/src/pipeline.ts:23:9 - error TS2322: Type
'unknown' is not assignable to type 'Error | undefined'.
  Type 'unknown' is not assignable to type 'Error'.

23         return e;
           ~~~~~~~~~

Found 1 error.
```